### PR TITLE
increase priority when navigate in xbmc

### DIFF
--- a/content/etc/init/xbmc-priority.conf
+++ b/content/etc/init/xbmc-priority.conf
@@ -21,10 +21,7 @@ script
 		'2')
 			renice -n 0 -p $(pidof xbmc.bin) 
 			;;
-		'3')
-			renice -n -2 -p $(pidof xbmc.bin) 
-			;;
-		'4')
+		'3'|'4')
 			renice -n $PPLAYER -p $(pidof xbmc.bin) 
 			;;
 		'5')


### PR DESCRIPTION
in Devel repo, i see you've set default priority to 0 for xbmcplevel=3, are there a reason?
xbmc should have a lower nice level when navigate in menu?
